### PR TITLE
Fix compatibility with scikit-learn 1.8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,7 @@ In the modifier version of NiaAML optimization process there are two types of op
 
 ```python
 self._params = dict(
-    n_estimators = ParameterDefinition(MinMax(min=10, max=111), np.uint),
-    algorithm = ParameterDefinition(['SAMME', 'SAMME.R'])
+    n_estimators = ParameterDefinition(MinMax(min=10, max=111), np.uint)
 )
 ```
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -181,8 +181,7 @@ In NiaAML there are two types of optimization. Goal of the first type is to find
 .. code:: python
 
     self._params = dict(
-        n_estimators = ParameterDefinition(MinMax(min=10, max=111), np.uint),
-        algorithm = ParameterDefinition(['SAMME', 'SAMME.R'])
+        n_estimators = ParameterDefinition(MinMax(min=10, max=111), np.uint)
     )
 
 An individual in the second type of optimization is a real-valued vector that has a size equal to the sum of number of keys in all three dictionaries (classifier's _params, feature transformation algorithm's _params and feature selection algorithm's _params) and a value of each dimension is in range [0.0, 1.0]. The second type of optimization maps real values from the individual's vector to those parameter definitions in the dictionaries. Each parameter's value can be defined as a range or array of values. In the first case, a value from vector is mapped from one iterval to another and in the second case, a value from vector falls into one of the bins that represent an index of the array that holds possible parameter's values.

--- a/examples/classifier.py
+++ b/examples/classifier.py
@@ -19,7 +19,7 @@ data_reader = CSVDataReader(
 classifier = AdaBoost()
 
 # set parameters of the classifier
-classifier.set_parameters(n_estimators=50, algorithm="SAMME")
+classifier.set_parameters(n_estimators=50)
 
 # fit classifier to the data
 classifier.fit(data_reader.get_x(), data_reader.get_y())

--- a/niaaml/classifiers/ada_boost.py
+++ b/niaaml/classifiers/ada_boost.py
@@ -51,9 +51,8 @@ class AdaBoost(Classifier):
 
         self._params = dict(
             n_estimators=ParameterDefinition(MinMax(min=10, max=111), np.uint),
-            algorithm=ParameterDefinition(["SAMME"]),
         )
-        self.__ada_boost = AdaBoostClassifier(algorithm='SAMME')
+        self.__ada_boost = AdaBoostClassifier()
 
     def set_parameters(self, **kwargs):
         r"""Set the parameters/arguments of the algorithm."""


### PR DESCRIPTION
scikit-learn 1.8.0+ removed the algorithm parameter from AdaBoostClassifier

https://github.com/scikit-learn/scikit-learn/pull/32262

The changes maintain compatibility with previous version of scikit-learn

> 🙇💖 Thank you for contributing to NiaAML!

> 🚮 feel free to delete any section that is not helpful/required for your report (including this message)

## ❗ Issue Links
Fixes #98 

## 🧪 How Has This Been Tested?

I've tested it on Fedora Rawhide with both scikit-learn 1.7.2 and scikit-learn 1.8.0rc1 and all the tests pass

# ✅ Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
