### PR TITLE
Fix undeclared dependency on typing-extensions

### DIFF
--- a/niaaml/cli.py
+++ b/niaaml/cli.py
@@ -1,12 +1,11 @@
 """🧑‍💻 command line interface for NiaAML"""
 
 from pathlib import Path
-from typing import Optional
+from typing import Annotated, Optional
 
 from loguru import logger
 import pandas as pd
 import typer
-from typing_extensions import Annotated
 
 from niaaml import PipelineOptimizer, Pipeline
 from niaaml.data.csv_data_reader import CSVDataReader


### PR DESCRIPTION
## 💬 Description

Instead of importing `Annotated` from `typing_extensions`, import it from `typing`; this requires Python 3.9 or later.

This fixes an undeclared runtime dependency on `typing-extensions`.

Even Python 3.9 is [already at end of life](https://devguide.python.org/versions/), let alone older releases, and you already require Python 3.10+,

https://github.com/firefly-cpp/NiaAML/blob/6e6798f6ee2a5eff4e2db10bfbc6f6e0f4f6fa52/pyproject.toml#L23

so it should be fine to make this change unconditionally.

## ❗ Issue Links
Fixes #100

## 🧪 How Has This Been Tested?

```
$ python3.13 --version
Python 3.13.13
$ python3.13 -m venv _e
$ . _e/bin/activate
(_e) $ pip install poetry
(_e) $ poetry install
(_e) $ pytest -v
[…]
======================================================================== 71 passed, 86 warnings in 78.52s (0:01:18) =========================================================================
```

# ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas **N/A, trivial**
- [x] I have made corresponding changes to the documentation **N/A, trivial**
- [x] I have added tests that prove my fix is effective or that my feature works  **N/A, no obvious way to test for implicit dependencies**
- [x] New and existing unit tests pass locally with my changes
